### PR TITLE
[feature] Add Font Shadow options for text

### DIFF
--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -125,6 +125,8 @@ if L then
     L["SpellnameFontDescription"] = "Sets the font of the text besides the icon."
     L["SpellnameFontFlag"] = "Additional Font Settings"
     L["SpellnameFontFlagDescription"] = "Sets additional font settings of the text besides the icon."
+    L["SpellnameEnableShadow"] = "Enable Text Shadow"
+    L["SpellnameEnableShadowDescription"] = "Enables or disables the shadow effect on the text."
     L["SpellnameDefaultColor"] = "Default Text Color"
     L["SpellnameDefaultColorDescription"] = "Sets the default color of the text besides the icon when not impacted by specific information like the type of debuff e.G. Poison."
     L["SpellnameUseEventColor"] = "Use Event Color"

--- a/Options/SpellIconsSettings.lua
+++ b/Options/SpellIconsSettings.lua
@@ -370,6 +370,16 @@ local createTextSettings = function(widget, parentWindow, iconSettings, textSett
 
     
 
+    local textShadowToggle = AceGUI:Create("CheckBox")
+    textShadowToggle:SetValue(textSettings.enableShadow)
+    textShadowToggle:SetLabel(private.getLocalisation("SpellnameEnableShadow"))
+    private.AddFrameTooltip(textShadowToggle.frame, "SpellnameEnableShadowDescription")
+    textShadowToggle:SetCallback("OnValueChanged", function(_, _, value)
+        textSettings.enableShadow = value
+        widget:ApplySettings()
+    end)
+    scroll:AddChild(textShadowToggle)
+
     local textBackgroundToggle = AceGUI:Create("CheckBox")
     textBackgroundToggle:SetValue(textSettings.useBackground)
     textBackgroundToggle:SetLabel(private.getLocalisation("SpellnameBackground"))
@@ -482,6 +492,16 @@ local createHighlightTextTextSettings = function(widget, parentWindow, textSetti
         widget:ApplySettings()
     end)
     scroll:AddChild(textDefaultColorSetting)
+
+    local textShadowToggle = AceGUI:Create("CheckBox")
+    textShadowToggle:SetValue(textSettings.enableShadow)
+    textShadowToggle:SetLabel(private.getLocalisation("SpellnameEnableShadow"))
+    private.AddFrameTooltip(textShadowToggle.frame, "SpellnameEnableShadowDescription")
+    textShadowToggle:SetCallback("OnValueChanged", function(_, _, value)
+        textSettings.enableShadow = value
+        widget:ApplySettings()
+    end)
+    scroll:AddChild(textShadowToggle)
 
     local textBackgroundToggle = AceGUI:Create("CheckBox")
     textBackgroundToggle:SetValue(textSettings.useBackground)

--- a/Templates/AtAbilitySpellIcon.lua
+++ b/Templates/AtAbilitySpellIcon.lua
@@ -510,6 +510,12 @@ local function ApplySettings(self)
 		)
 	end
 
+	if private.db.profile.text_settings and private.db.profile.text_settings.enableShadow then
+		self.frame.SpellName:SetShadowColor(0, 0, 0, 1)
+	else
+		self.frame.SpellName:SetShadowColor(0, 0, 0, 0)
+	end
+
 	if private.db.profile.icon_settings and private.db.profile.icon_settings.strata then
 		self.frame:SetFrameStrata(private.db.profile.icon_settings.strata)
 	end

--- a/Templates/AtBigIcon.lua
+++ b/Templates/AtBigIcon.lua
@@ -121,6 +121,12 @@ local function ApplySettings(self)
 		)
 	end
 
+	if private.db.profile.big_icon_text_settings and private.db.profile.big_icon_text_settings.enableShadow then
+		self.frame.SpellName:SetShadowColor(0, 0, 0, 1)
+	else
+		self.frame.SpellName:SetShadowColor(0, 0, 0, 0)
+	end
+
 	if not self.frame.SpellIcon.zoomApplied or self.frame.SpellIcon.zoomApplied ~= (1 - private.db.profile.big_icon_settings.zoom) then
 		if self.frame.SpellIcon.zoomApplied then
 			private.ResetZoom(self.frame.SpellIcon)

--- a/Templates/AtTextHighlight.lua
+++ b/Templates/AtTextHighlight.lua
@@ -28,6 +28,12 @@ local function ApplySettings(self)
         )
     end
 
+    if private.db.profile.highlight_text_settings and private.db.profile.highlight_text_settings.enableShadow then
+        self.frame.SpellName:SetShadowColor(0, 0, 0, 1)
+    else
+        self.frame.SpellName:SetShadowColor(0, 0, 0, 0)
+    end
+
     if private.db.profile.highlight_text_settings and private.db.profile.highlight_text_settings.strata then
 		self.frame:SetFrameStrata(private.db.profile.highlight_text_settings.strata)
 	end

--- a/Util/ModernizeSettings.lua
+++ b/Util/ModernizeSettings.lua
@@ -123,6 +123,9 @@ private.modernize = function()
             OUTLINE = true,
         }
     end
+    if private.db.profile.text_settings.enableShadow == nil then
+        private.db.profile.text_settings.enableShadow = true
+    end
     if private.db.profile.text_settings.useBackground == nil then
         private.db.profile.text_settings.useBackground = false
     end
@@ -156,6 +159,9 @@ private.modernize = function()
             OUTLINE = true,
         }
     end
+    if private.db.profile.big_icon_text_settings.enableShadow == nil then
+        private.db.profile.big_icon_text_settings.enableShadow = true
+    end
     if private.db.profile.big_icon_text_settings.useBackground == nil then
         private.db.profile.big_icon_text_settings.useBackground = false
     end
@@ -183,6 +189,9 @@ private.modernize = function()
     end
     if not private.db.profile.highlight_text_settings.font then
         private.db.profile.highlight_text_settings.font = "Friz Quadrata TT"
+    end
+    if private.db.profile.highlight_text_settings.enableShadow == nil then
+        private.db.profile.highlight_text_settings.enableShadow = true
     end
     if private.db.profile.highlight_text_settings.useBackground == nil then
         private.db.profile.highlight_text_settings.useBackground = false


### PR DESCRIPTION
Adds "Enable Text Shadow" option on all Text Settings entries - Spell Icon, Big Icon, Text Highlight
<img width="426" height="517" alt="image" src="https://github.com/user-attachments/assets/6ccb6f0c-9071-4053-a3f8-fa20c4d2f47a" />
Enabled:
<img width="315" height="62" alt="image" src="https://github.com/user-attachments/assets/5cab5bcc-727c-41e3-b4b4-71de826f7dd8" />
Disabled: 
<img width="295" height="46" alt="image" src="https://github.com/user-attachments/assets/0b89e8fc-1b0e-4461-9d48-01fbb4f63479" />

Closes #64 and #44 